### PR TITLE
ensure the file exists when using an AppendOp over an existing ReplaceOp

### DIFF
--- a/Operations/AppendOp.php
+++ b/Operations/AppendOp.php
@@ -3,6 +3,7 @@
 namespace Drupal\Composer\Plugin\Scaffold\Operations;
 
 use Composer\IO\IOInterface;
+use Composer\Util\Filesystem;
 use Drupal\Composer\Plugin\Scaffold\ScaffoldFilePath;
 use Drupal\Composer\Plugin\Scaffold\ScaffoldOptions;
 
@@ -105,6 +106,7 @@ class AppendOp extends AbstractOperation {
    * {@inheritdoc}
    */
   public function process(ScaffoldFilePath $destination, IOInterface $io, ScaffoldOptions $options) {
+    $fs = new Filesystem();
     $destination_path = $destination->fullPath();
     $interpolator = $destination->getInterpolator();
 
@@ -133,6 +135,7 @@ class AppendOp extends AbstractOperation {
     }
 
     // Write the resulting data
+    $fs->ensureDirectoryExists(dirname($destination_path));
     file_put_contents($destination_path, $this->contents());
 
     // Return a ScaffoldResult with knowledge of whether this file is managed.


### PR DESCRIPTION
Hello,

I've found a bug when using a particular config in my project (exemple below). The main info is that I'm Skipping or Appending every file inside **sites/default**.

```
{
  "name": "*******",
  "repositories": [
      {
          "type": "composer",
          "url": "https://packages.drupal.org/8"
      }
  ],
  "require": {
      "composer/installers": "^1.9",
      "drupal/admin_toolbar": "^3.0",
      "drupal/core-composer-scaffold": "^9.2",
      "drupal/core-recommended": "^9.2",
      "drush/drush": "^10.5"
  },
  "conflict": {
      "drupal/drupal": "*"
  },
  "minimum-stability": "stable",
  "prefer-stable": true,
  "config": {
      "sort-packages": true
  },
  "extra": {
      "drupal-scaffold": {
          "locations": {
              "web-root": "web/"
          },
          "file-mapping": {
              "[web-root]/.csslintrc": false,
              "[web-root]/.eslintignore": false,
              "[web-root]/.eslintrc.json": false,
              "[web-root]/.ht.router.php": false,
              "[web-root]/example.gitignore": false,
              "[web-root]/INSTALL.txt": false,
              "[web-root]/README.md": false,
              "[web-root]/update.php": false,
              "[web-root]/web.config": false,
              "[web-root]/sites/README.txt": false,
              "[web-root]/sites/development.services.yml": false,
              "[web-root]/sites/example.settings.local.php": false,
              "[web-root]/sites/example.sites.php": false,
              "[web-root]/sites/default/default.services.yml": false,
              "[web-root]/modules/README.txt": false,
              "[web-root]/profiles/README.txt": false,
              "[web-root]/themes/README.txt": false,
              "[web-root]/sites/default/default.settings.php": {
                  "mode": "append",
                  "append": "assets/default-settings-php-additions.txt"
              }
          }
      },
      "installer-paths": {
          "web/core": [
              "type:drupal-core"
          ],
          "web/libraries/{$name}": [
              "type:drupal-library"
          ],
          "web/modules/contrib/{$name}": [
              "type:drupal-module"
          ],
          "web/profiles/contrib/{$name}": [
              "type:drupal-profile"
          ],
          "web/themes/contrib/{$name}": [
              "type:drupal-theme"
          ],
          "drush/Commands/contrib/{$name}": [
              "type:drupal-drush"
          ],
          "web/modules/custom/{$name}": [
              "type:drupal-custom-module"
          ],
          "web/profiles/custom/{$name}": [
              "type:drupal-custom-profile"
          ],
          "web/themes/custom/{$name}": [
              "type:drupal-custom-theme"
          ]
      }
  },
  "require-dev": {
      "drupal/devel": "^4.1",
      "kint-php/kint": "^3.3",
      "marcocesarato/php-conventional-changelog": "^1.10"
  },
  "scripts": {
      "changelog": "conventional-changelog --history"
  },
  "version": "1.0.0"
}
```

In this case,  the **sites/default** directory is never created by a ReplaceOp and the AppendOp fails with a 

```
[ErrorException]                                                                                               
  file_put_contents(/workspace/backend/web/sites/default/default.settings.php): Failed to open stream: No such   
  file or directory 
```

I'm suggesting the following modification to fix this.

Regards